### PR TITLE
use/utf-8;use set(TARGET_NAME XXX)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 # 最低cmake版本
 cmake_minimum_required(VERSION 3.14)
 
+set(TARGET_NAME MiraiCPPlugin)
 # 声明C++项目
-project(MiraiCPPlugin LANGUAGES CXX)
+project(${TARGET_NAME} LANGUAGES CXX)
 
 # C++ 标准：17+
 set(CMAKE_CXX_STANDARD 17) # 可以为20
@@ -25,7 +26,7 @@ if(MSVC)
     set(CMAKE_GENERATOR_PLATFORM x64)
 
     # C++17标准；异常处理模型：标准 C++ stack unwinding；启用多线程编译；禁止无返回值的函数；禁用两个与dll export相关的warning；加入__cplusplus宏支持
-    add_compile_options(/EHs /MP /std:c++17 /we4715 /wd4251 /wd4275 /wd4068 /Zc:__cplusplus /source-charset:utf-8)
+    add_compile_options(/EHs /MP /std:c++17 /we4715 /wd4251 /wd4275 /wd4068 /Zc:__cplusplus /utf-8)
 else()
     # 禁止无返回值的函数
     add_compile_options(-Wall -Werror=return-type)
@@ -60,41 +61,41 @@ file(GLOB PLUGIN_SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
 # 添加动态库编译目标
 add_library(
-    MiraiCPPlugin
+    ${TARGET_NAME}
     SHARED
     single_include/MiraiCP/MiraiCP.cpp # MiraiCP 源文件
     ${PLUGIN_SOURCE_PATH}
 )
 
 # 引入全部头文件路径
-target_include_directories(MiraiCPPlugin PUBLIC ${SOURCE_HEADER_PATH})
+target_include_directories(${TARGET_NAME} PUBLIC ${SOURCE_HEADER_PATH})
 
 # 需要的预定义宏
-target_compile_definitions(MiraiCPPlugin PUBLIC JSON_MultipleHeaders=ON MIRAICP_LIB_SDK)
+target_compile_definitions(${TARGET_NAME} PUBLIC JSON_MultipleHeaders=ON MIRAICP_LIB_SDK)
 
 # 开启所有warning
-target_compile_options(MiraiCPPlugin PUBLIC -Wall)
+target_compile_options(${TARGET_NAME} PUBLIC -Wall)
 
 # 关闭所有warning
-# target_compile_options(MiraiCPPlugin PUBLIC -w)
+# target_compile_options(${TARGET_NAME} PUBLIC -w)
 
 # 保证插件移植性，注意如果存在无法静态链接的其他依赖，仍然无法移植
-set_target_properties(MiraiCPPlugin PROPERTIES LINK_SEARCH_START_STATIC 1)
-set_target_properties(MiraiCPPlugin PROPERTIES LINK_SEARCH_END_STATIC 1)
+set_target_properties(${TARGET_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${TARGET_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
 
 if(WIN32)
     if(MSVC)
         if(CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
-            target_compile_options(MiraiCPPlugin PUBLIC /MT)
+            target_compile_options(${TARGET_NAME} PUBLIC /MT)
         else()
-            target_compile_options(MiraiCPPlugin PUBLIC /MTd)
+            target_compile_options(${TARGET_NAME} PUBLIC /MTd)
         endif()
     else()
-        target_link_options(MiraiCPPlugin PUBLIC -static)
+        target_link_options(${TARGET_NAME} PUBLIC -static)
     endif(MSVC)
 endif(WIN32)
 
 if(UNIX)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-    target_link_options(MiraiCPPlugin PUBLIC -static-libstdc++ -static-libgcc)
+    target_link_options(${TARGET_NAME} PUBLIC -static-libstdc++ -static-libgcc)
 endif(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 # 最低cmake版本
 cmake_minimum_required(VERSION 3.14)
 
-set(TARGET_NAME MiraiCPPlugin)
-# 声明C++项目
-project(${TARGET_NAME} LANGUAGES CXX)
-
 # C++ 标准：17+
 set(CMAKE_CXX_STANDARD 17) # 可以为20
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -13,89 +9,89 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # 在64位编译
 set(BUILD_USE_64BITS on)
 
-# json库启用C++17标准
-add_compile_definitions(JSON_HAS_CPP_17)
-
-if(WIN32)
-    # See Warning C4668
-    add_compile_definitions(WIN32_LEAN_AND_MEAN)
-endif(WIN32)
-
-# MSVC设置
-if(MSVC)
-    set(CMAKE_GENERATOR_PLATFORM x64)
-
-    # C++17标准；异常处理模型：标准 C++ stack unwinding；启用多线程编译；禁止无返回值的函数；禁用两个与dll export相关的warning；加入__cplusplus宏支持
-    add_compile_options(/EHs /MP /std:c++17 /we4715 /wd4251 /wd4275 /wd4068 /Zc:__cplusplus /utf-8)
-else()
-    # 禁止无返回值的函数
-    add_compile_options(-Wall -Werror=return-type)
-
-    # 隐藏符号表
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-endif(MSVC)
-
-# 优化选项，需要使用cmake -DCMAKE_BUILD_TYPE=Release 命令启用
-if(CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
-    message("Release build detected, enabling maximal optimization")
-
-    if(MSVC)
-        add_compile_options(/Ox)
-    else()
-        add_compile_options(-O3)
-    endif(MSVC)
-endif(CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
+# 声明C++项目
+project(MIRAICP_TEMPLATE LANGUAGES CXX)
 
 # 寻找库的头文件
 set(
-    SOURCE_HEADER_PATH
-    ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/json
-    ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/json/nlohmann
-    ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/utf8
-    ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/utf8/utf8
-    ${CMAKE_CURRENT_SOURCE_DIR}/single_include/MiraiCP
+        MIRAICP_SOURCE_HEADER_PATH
+        ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/json
+        ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/json/nlohmann
+        ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/utf8
+        ${CMAKE_CURRENT_SOURCE_DIR}/single_include/3rd_include/utf8/utf8
+        ${CMAKE_CURRENT_SOURCE_DIR}/single_include/MiraiCP
 )
 
 # 添加src目录下所有源文件（每次新增文件不要修改cmake，只需重新执行cmake命令）
 file(GLOB PLUGIN_SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
 # 添加动态库编译目标
+set(MIRAICP_TARGET_NAME MiraiCPPlugin)
 add_library(
-    ${TARGET_NAME}
-    SHARED
-    single_include/MiraiCP/MiraiCP.cpp # MiraiCP 源文件
-    ${PLUGIN_SOURCE_PATH}
+        ${MIRAICP_TARGET_NAME}
+        SHARED
+        single_include/MiraiCP/MiraiCP.cpp # MiraiCP 源文件
+        ${PLUGIN_SOURCE_PATH}
 )
 
+# json库启用C++17标准
+target_compile_definitions(${MIRAICP_TARGET_NAME} PUBLIC JSON_HAS_CPP_17)
+
+if (WIN32)
+    # See Warning C4668
+    target_compile_definitions(${MIRAICP_TARGET_NAME} PUBLIC WIN32_LEAN_AND_MEAN)
+endif (WIN32)
+
+# MSVC设置
+if (MSVC)
+    # C++17标准；异常处理模型：标准 C++ stack unwinding ；启用多线程编译；禁止无返回值的函数；禁用两个与 dll export 相关的 warnings ；加入 __cplusplus 宏支持
+    target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC /W4 /EHs /MP /std:c++17 /we4715 /wd4251 /wd4275 /wd5045 /wd4068 /Zc:__cplusplus /utf-8)
+    # 注意：如果在其他文件使用 wstring 以及非 utf-8 编码，删除 /utf-8 参数并使用：
+    # set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/single_include/MiraiCP/MiraiCP.cpp PROPERTIES COMPILE_FLAGS /utf-8)
+else ()
+    # 禁止无返回值的函数；隐藏符号表
+    target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC -Wall -Werror=return-type -fvisibility=hidden)
+endif (MSVC)
+
 # 引入全部头文件路径
-target_include_directories(${TARGET_NAME} PUBLIC ${SOURCE_HEADER_PATH})
+target_include_directories(${MIRAICP_TARGET_NAME} PUBLIC ${MIRAICP_SOURCE_HEADER_PATH})
 
 # 需要的预定义宏
-target_compile_definitions(${TARGET_NAME} PUBLIC JSON_MultipleHeaders=ON MIRAICP_LIB_SDK)
+target_compile_definitions(${MIRAICP_TARGET_NAME} PUBLIC JSON_MultipleHeaders=ON MIRAICP_LIB_SDK)
 
-# 开启所有warning
-target_compile_options(${TARGET_NAME} PUBLIC -Wall)
+#################################################################################################
 
-# 关闭所有warning
-# target_compile_options(${TARGET_NAME} PUBLIC -w)
+# 优化选项，需要使用cmake -DCMAKE_BUILD_TYPE=Release 启用，可按需删除
+if (CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
+    message("Release build detected, enabling maximal optimization")
+    if (MSVC)
+        target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC /Ox)
+    else ()
+        target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC -O3)
+    endif (MSVC)
+endif (CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
+
+# 关闭所有warning，请按需使用
+# target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC -w)
 
 # 保证插件移植性，注意如果存在无法静态链接的其他依赖，仍然无法移植
-set_target_properties(${TARGET_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
-set_target_properties(${TARGET_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
+# 请按需删除下面所有的cmake内容
+set_target_properties(${MIRAICP_TARGET_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
+set_target_properties(${MIRAICP_TARGET_NAME} PROPERTIES LINK_SEARCH_END_STATIC 1)
 
-if(WIN32)
-    if(MSVC)
-        if(CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
-            target_compile_options(${TARGET_NAME} PUBLIC /MT)
-        else()
-            target_compile_options(${TARGET_NAME} PUBLIC /MTd)
-        endif()
-    else()
-        target_link_options(${TARGET_NAME} PUBLIC -static)
-    endif(MSVC)
-endif(WIN32)
+if (WIN32)
+    if (MSVC)
+        if (CMAKE_BUILD_TYPE MATCHES ".*Rel.*")
+            target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC /MT)
+        else ()
+            target_compile_options(${MIRAICP_TARGET_NAME} PUBLIC /MTd)
+        endif ()
+    else (MSVC)
+        target_link_options(${MIRAICP_TARGET_NAME} PUBLIC -static)
+    endif (MSVC)
+endif (WIN32)
 
-if(UNIX)
+if (UNIX)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-    target_link_options(${TARGET_NAME} PUBLIC -static-libstdc++ -static-libgcc)
-endif(UNIX)
+    target_link_options(${MIRAICP_TARGET_NAME} PUBLIC -static-libstdc++ -static-libgcc)
+endif (UNIX)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   - Windows上使用Visual Studio开发：首先需要[下载cmake](https://cmake.org/download/)并确保`cmake`已经被添加到`PATH`。在本目录下新建文件夹`build`，在`build`文件夹中打开powershell窗口，执行
 
     ```powershell
-    cmake .. -DCMAKE_GENERATOR_PLATFORM=x64 --config Release
+    cmake .. -A x64 --config Release
     ```
 
     即可生成Visual Studio项目。双击`MiraiCPPlugin.sln`打开项目编写、编译。


### PR DESCRIPTION
1. 只设置/source-charset而不设置/execution-charset的utf-8，会导致MSCV编译出的目标文件中字符串的编码格式为GB2312，导致使用utf8的MiraiCP-loader产生异常。（VS2019下测试通过）
这两个设置可以合并为/utf-8（就是旧版本模板的CMAKE用的那个）
详可见https://zhuanlan.zhihu.com/p/368695263?utm_id=0

2.使用 set(TARGET_NAME XXX)，后面直接${TARGET_NAME}，方便对修改模板

--------
以上于VS2019（WIN10专业版x64）和gcc version 11.3.0 (Ubuntu22.04 LTSC x64)下编译、测试通过 

