### PR TITLE
fix: MiraiCP.hpp

### DIFF
--- a/single_include/MiraiCP/MiraiCP.hpp
+++ b/single_include/MiraiCP/MiraiCP.hpp
@@ -1145,7 +1145,7 @@ namespace MiraiCP {
         /// 筛选出某种类型的消息
         /// @note 最多可能将整个vector复制一次
         template<typename T>
-        std::vector<T> filter() {
+        std::vector<T> filter() const {
             static_assert(std::is_base_of_v<SingleMessage, T>, "只支持SingleMessage的子类");
             std::vector<T> re;
             for (auto &&a: *this) {
@@ -1157,7 +1157,7 @@ namespace MiraiCP {
         /// 自定义筛选器
         /// @note 最多可能将整个vector复制一次
         template<typename T>
-        std::vector<T> filter(const std::function<bool(const Message &)> &func) {
+        std::vector<T> filter(const std::function<bool(const Message &)> &func) const {
             static_assert(std::is_base_of_v<SingleMessage, T>, "只支持SingleMessage的子类");
             std::vector<T> re;
             for (auto &&a: *this) {
@@ -1168,7 +1168,7 @@ namespace MiraiCP {
         }
         /// 找出第一个指定的type的消息，消息可能不存在
         template<typename T>
-        std::optional<T> first() {
+        std::optional<T> first() const {
             for (auto &&a: *this)
                 if (a.getType() == T::type())
                     return a.getVal<T>();


### PR DESCRIPTION
在使用`MessageChain::first()`时，发现函数体没有被声明为`const`：
`auto firstImage = e.message.first<Image>();`
会提示如下错误
`error: passing 'const MiraiCP::MessageChain' as 'this' argument discards qualifiers [-fpermissive]`
